### PR TITLE
fix: [DDS-175] 2nd round of dependency updates

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3672,17 +3672,10 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.12.0, js-yaml@^3.7.0:
+js-yaml@^3.12.0, js-yaml@^3.7.0, js-yaml@^3.9.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
-js-yaml@^3.9.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3977,14 +3977,10 @@ lodash.toarray@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
 
-lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
+lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
-lodash@^4.17.5, lodash@^4.2.1:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
 log-symbols@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## CHANGE TYPE(S)

_Check ✅ one. Only in rare cases should you need to check *more* than one:_

- [ ] ✨ `feat`: A new feature
- [x] 🐛 `fix`: A bug fix
- [ ] 📖 `docs`: Documentation only changes
- [ ] 💅 `style`: Changes that do not affect the meaning of the code
      (white-space, formatting, missing semi-colons, etc)
- [ ] 📦 `refactor`: A code change that neither fixes a bug nor adds a feature
- [ ] 🚀 `perf`: A code change that improves performance
- [ ] 🚨 `test`: Adding missing tests or correcting existing tests
- [ ] 👷 `build`: Changes that affect the build system or external dependencies
- [ ] 💻 `ci`: Changes to our CI configuration files and scripts
- [x] 🛁 `chore`: Other changes that don't modify src or test files
- [ ] 🔙 `revert`: Reverts a previous commit

## DESCRIPTION

Updated dependencies for lodash and js-yaml per security alerts.

## WHERE SHOULD THE REVIEWER START?

`yarn.lock`

## BREAKING CHANGES

None.

## ANY NEW DEPENDENCIES ADDED?

* bumped lodash to 4.17.15
* bumped js-yaml to 3.13.1

## CHECKLIST

- [x] I rebased this branch on the latest `master`
- [x] I ran the linting process - `yarn lint` - and fixed any errors
- [x] I ran the test suite - `yarn test` - and fixed any failing tests
- [x] I verified that coverage has not been _reduced_ by this PR

## GIF

![](http://giphygifs.s3.amazonaws.com/media/KEh5kliRTSVJm/giphy.gif)
